### PR TITLE
[fix] defaultStatus 오타 수정

### DIFF
--- a/app/service/guide/page.jsx
+++ b/app/service/guide/page.jsx
@@ -113,7 +113,7 @@ export default function Service() {
                 }}
               >
                 <Suspense>
-                  <PinNumber defaultStage={'auth'} defaultStatus={'transfer'} data={'함께 보내야 하는 데이터'} />
+                  <PinNumber defaultStage={'auth'} defaultStatus={'transferMyage'} data={'함께 보내야 하는 데이터'} />
                 </Suspense>
               </Modal>
             </Box>

--- a/components/common/PinNumber/PinNumber.jsx
+++ b/components/common/PinNumber/PinNumber.jsx
@@ -12,7 +12,7 @@ import { useSignupStore } from '@/stores/authStore';
 import { signUp } from '@/apis/authAPI';
 import { updatePinNumber, verifyPinNumber } from '@/apis/mypageAPI';
 
-export default function PinNumber({ defaultStage, dafaultStatus, data }) {
+export default function PinNumber({ defaultStage, defaultStatus, data }) {
   // 입력값 관리
   const { control, handleSubmit, reset } = useForm();
   const [pin, setPin] = useState(['', '', '', '', '', '']);
@@ -24,7 +24,7 @@ export default function PinNumber({ defaultStage, dafaultStatus, data }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const stage = searchParams?.get('stage') || defaultStage;
-  const status = searchParams?.get('status');
+  const status = searchParams?.get('status') || defaultStatus;
 
   // 키보드 랜덤 배열
   useEffect(() => {
@@ -174,8 +174,12 @@ export default function PinNumber({ defaultStage, dafaultStatus, data }) {
     if (stage == 'auth') {
       console.log(pinNumber); // 입력한 pin번호
       console.log(data); // 위에서 props로 내려준 data
-      if (status == 'transfer') {
-        // 이체 로직
+      console.log(status);
+      if (status == 'transferMyage') {
+        // 마이페이지 이체 로직
+      }
+      if (status == 'transferAgit') {
+        // 아지트 이체 로직
       }
       if (status == 'payment') {
         // 결제 로직
@@ -248,7 +252,7 @@ export default function PinNumber({ defaultStage, dafaultStatus, data }) {
           <Box className="btn_group">
             {stage == 'create' && status == undefined && <ButtonM rightButton={{ type: 'submit', text: '생성' }} />}
             {(status == 'confirm' ||
-              (stage == 'auth' && status == undefined) ||
+              stage == 'auth' ||
               (stage == 'update' && (status == undefined || status == 'changeConfirm'))) && (
               <ButtonM rightButton={{ type: 'submit', text: '확인', isLoading }} />
             )}


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #18 

## 📝작업 내용
- PinNumber에서 defaultStatus props 오타 수정
- 인증 할때에서 status를 마이페이지 이체/아지트 이체로 구분

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6688d4ed-3fa8-476a-a698-d6c3642b0048)
![image](https://github.com/user-attachments/assets/169f2f5a-1d04-4f0f-acde-9d0596f9cfb0)
- 마이페이지 이체가 transferMyage, 아지트 이체가 transferAgit 입니다
- BE service에 올린 PR중 MemberServiceImpl에 핀번호 검사하는 부분 있으니 이것도 참고하세요 (아직 병합안됨)
![image](https://github.com/user-attachments/assets/878429dc-ee3a-4425-8d99-717a4a30cdc6)

## 💬리뷰 요구사항(선택)
